### PR TITLE
Fix issue with generating hash for files created by the pipeline

### DIFF
--- a/lib/performHash.js
+++ b/lib/performHash.js
@@ -11,10 +11,10 @@ function performHash(format, file) {
     "name": fname,
     "ext": ext,
     "hash": generateHash(file.contents),
-    "size": file.stat.size,
-    "atime": getDateStr(file.stat.atime),
-    "ctime": getDateStr(file.stat.ctime),
-    "mtime": getDateStr(file.stat.mtime),
+    "size":  file.stat ? file.stat.size : '',
+    "atime": file.stat ? getDateStr(file.stat.atime) : '',
+    "ctime": file.stat ? getDateStr(file.stat.ctime) : '',
+    "mtime": file.stat ? getDateStr(file.stat.mtime) : '',
   };
   var fileName = formatStr(format, params);
   file.path = path.join(dir, fileName);

--- a/test/performHash.test.js
+++ b/test/performHash.test.js
@@ -54,4 +54,15 @@ describe('performHash.js', function () {
       resolve();
     });
   });
+
+  it('should handle generated files', function() {
+    return new Promise(function(resolve, reject) {
+      file = {
+        path: '/dog/cat/myFile.txt',
+        contents: 'this is a test',
+      }
+      expect(performHash('{size}|{atime}|{ctime}|{mtime}', file).path).to.equal('/dog/cat/|||');
+      resolve();
+    });
+  });
 });


### PR DESCRIPTION
When adding hashRename to files generated by a gulp pipeline (ie, files that didn't come from the file system), `file.stat` is not available. For example:

```javascript
  return gulp.src(webpackSources(srcRoot, webpackOpts.entry))
    .pipe(webpackStream(webpackOpts))
    .pipe(hashFilename({ format: '{name}.{hash}{ext}' }))
    .pipe(gulp.dest(destRoot));
```

In these cases, hash-filename will fail with `TypeError: Cannot read property 'size' of undefined`. This patch fixes that by providing an empty string for any `file.stat`-based properties.